### PR TITLE
Bootstrap LDAP with user provided LDIF file(s)

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -50,6 +50,8 @@ export LDAP_USERS="${LDAP_USERS:-user01,user02}"
 export LDAP_PASSWORDS="${LDAP_PASSWORDS:-bitnami1,bitnami2}"
 export LDAP_USER_DC="${LDAP_USER_DC:-users}"
 export LDAP_GROUP="${LDAP_GROUP:-readers}"
+export LDAP_LOAD_CUSTOM_LDIF="${LDAP_LOAD_CUSTOM_LDIF:-no}"
+export LDAP_CUSTOM_LDIF_DIR="${LDAP_CUSTOM_LDIF_DIR:-/ldifs}"
 EOF
 }
 
@@ -296,6 +298,20 @@ EOF
 }
 
 ########################
+# Add custom LDIF files
+# Globals:
+#   LDAP_*
+# Arguments:
+#   None
+# Returns
+#   None
+#########################
+ldap_add_custom_ldifs() {
+    info "Loading custom LDIF files..."
+    debug_execute find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 -type f -iname '*.ldif' -exec ldapadd -f {} -H 'ldapi:///' -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD" \;
+}
+
+########################
 # OpenLDAP configure perissions
 # Globals:
 #   LDAP_*
@@ -306,7 +322,7 @@ EOF
 #########################
 ldap_configure_permissions() {
   debug "Ensuring expected directories/files exist..."
-  for dir in "$LDAP_SHARE_DIR" "$LDAP_DATA_DIR" "$LDAP_ONLINE_CONF_DIR"; do
+  for dir in "$LDAP_SHARE_DIR" "$LDAP_DATA_DIR" "$LDAP_ONLINE_CONF_DIR" "$LDAP_CUSTOM_LDIF_DIR"; do
       ensure_dir_exists "$dir"
       if am_i_root; then
           chown -R "$LDAP_DAEMON_USER:$LDAP_DAEMON_GROUP" "$dir"
@@ -339,7 +355,11 @@ ldap_initialize() {
         else
             # Initialize OpenLDAP with schemas/tree structure
             ldap_add_schemas
-            ldap_create_tree
+            if is_boolean_yes "$LDAP_LOAD_CUSTOM_LDIF"; then
+                ldap_add_custom_ldifs
+            else
+                ldap_create_tree
+            fi
         fi
         ldap_stop
     fi

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -50,7 +50,6 @@ export LDAP_USERS="${LDAP_USERS:-user01,user02}"
 export LDAP_PASSWORDS="${LDAP_PASSWORDS:-bitnami1,bitnami2}"
 export LDAP_USER_DC="${LDAP_USER_DC:-users}"
 export LDAP_GROUP="${LDAP_GROUP:-readers}"
-export LDAP_LOAD_CUSTOM_LDIF="${LDAP_LOAD_CUSTOM_LDIF:-no}"
 export LDAP_CUSTOM_LDIF_DIR="${LDAP_CUSTOM_LDIF_DIR:-/ldifs}"
 EOF
 }
@@ -308,6 +307,7 @@ EOF
 #########################
 ldap_add_custom_ldifs() {
     info "Loading custom LDIF files..."
+    warn "Ignoring LDAP_USERS, LDAP_PASSWORDS, LDAP_USER_DC and LDAP_GROUP environment variables..."
     debug_execute find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 -type f -iname '*.ldif' -exec ldapadd -f {} -H 'ldapi:///' -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD" \;
 }
 
@@ -355,7 +355,7 @@ ldap_initialize() {
         else
             # Initialize OpenLDAP with schemas/tree structure
             ldap_add_schemas
-            if is_boolean_yes "$LDAP_LOAD_CUSTOM_LDIF"; then
+            if [[ -n "$LDAP_CUSTOM_LDIF_DIR" ]]; then
                 ldap_add_custom_ldifs
             else
                 ldap_create_tree

--- a/2/debian-10/rootfs/opt/bitnami/scripts/openldap/postunpack.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/openldap/postunpack.sh
@@ -15,7 +15,7 @@ set -o pipefail
 eval "$(ldap_env)"
 
 # Ensure non-root user has write permissions on a set of directories
-for dir in "$LDAP_SHARE_DIR" "$LDAP_DATA_DIR" "$LDAP_ONLINE_CONF_DIR" "${LDAP_BASE_DIR}/var"; do
+for dir in "$LDAP_SHARE_DIR" "$LDAP_DATA_DIR" "$LDAP_ONLINE_CONF_DIR" "${LDAP_BASE_DIR}/var" "$LDAP_CUSTOM_LDIF_DIR"; do
     ensure_dir_exists "$dir"
     chmod -R g+rwX "$dir"
 done

--- a/README.md
+++ b/README.md
@@ -176,8 +176,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_USER_DC`: DC for the users' organizational unit. Default: **users**
 - `LDAP_GROUP`: Group used to group created users. Default: **readers**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
-- `LDAP_LOAD_CUSTOM_LDIF`: Whether to load user provided custom LDIF files. Default: **no**
-- `LDAP_CUSTOM_LDIF_DIR`: Location of the directory that contains the LDIF files to be loaded when `LDAP_LOAD_CUSTOM_LDIF` is true. Default: **/ldifs**
+- `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Only files ending in `.ldif` will be used. Default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` will be skipped when `LDAP_CUSTOM_LDIF_DIR` is used. Default: **/ldifs**
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_USER_DC`: DC for the users' organizational unit. Default: **users**
 - `LDAP_GROUP`: Group used to group created users. Default: **readers**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
+- `LDAP_LOAD_CUSTOM_LDIF`: Whether to load user provided custom LDIF files. Default: **no**
+- `LDAP_CUSTOM_LDIF_DIR`: Location of the directory that contains the LDIF files to be loaded when `LDAP_LOAD_CUSTOM_LDIF` is true. Default: **/ldifs**
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.
 


### PR DESCRIPTION
**Description of the change**

This change allows for the user to provide LDIF files to bootstrap the LDAP directory during the initial startup. 

It is mutually exclusive with the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` environment variables.
Maybe the Readme file should reflect this more precisely than I did.

**Benefits**

The LDAP server can be bootstrapped with LDIF file(s) mounted in the container at the location refered to by the `LDAP_CUSTOM_LDIF_DIR` environment variable.  
This feature is enabled when environment variables `LDAP_LOAD_CUSTOM_LDIF` is `yes` and `LDAP_SKIP_DEFAULT_TREE` is `no`.

**Possible drawbacks**

The way I handled the LDAP schema might not be suitable in all situation.  
I guess we should also add the possibility of loading custom schema via LDIF files.

**Applicable issues**

Provides the feature requested in #7.
