### PR TITLE
fix group creation for multiple members

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -290,9 +290,15 @@ EOF
 dn: ${LDAP_GROUP/#/cn=},${LDAP_USER_DC/#/ou=},${LDAP_ROOT}
 cn: $LDAP_GROUP
 objectClass: groupOfNames
-member: ${users[@]/#/cn=},${LDAP_USER_DC/#/ou=},${LDAP_ROOT}
-
+# User group membership
 EOF
+
+    for user in "${users[@]}"; do
+        cat >> "${LDAP_SHARE_DIR}/tree.ldif" << EOF
+member: ${user/#/cn=},${LDAP_USER_DC/#/ou=},${LDAP_ROOT}
+EOF
+    done
+
     debug_execute ldapadd -f "${LDAP_SHARE_DIR}/tree.ldif" -H "ldapi:///" -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD"
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This changes the created LDAP group to have a `member: ...` line for each configured user.

**Benefits**

LDAP searches that look for users in a group work as expected, e.g. using the default settings of this image:

```
base: cn=readers,ou=users,dc=example,dc=org
filter: (member=cn=user01,ou=users,dc=example,dc=org)
```

**Possible drawbacks**

I think there are none, however would love to get feedback on this.

**Applicable issues**

I have not created one, but instead opened this PR. The issue I'm seeing is that searching for members in the group does not work as expected as long as there is more than one user configured. If there is only a single user configured, everything works as expected.

**Additional information**

Thanks for this image - helped me a lot while setting up a test environment :heart: 
