### PR TITLE
Allow using both LDAP_ROOT and Custom Ldif files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docker-compose-dev.yml
+imports

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-docker-compose-dev.yml
-imports

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -355,10 +355,10 @@ ldap_initialize() {
         else
             # Initialize OpenLDAP with schemas/tree structure
             ldap_add_schemas
+            ldap_create_tree
+
             if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
                 ldap_add_custom_ldifs
-            else
-                ldap_create_tree
             fi
         fi
         ldap_stop


### PR DESCRIPTION

**Description of the change**

Invoke `ldap_create_tree` even if some custom ldif files do exist in `$LDAP_CUSTOM_LDIF_DIR`

**Benefits**

You might have a LDAP_ROOT defined to create the Ldap root and some  Custom Ldif files to create some data under that root (i.e. People).
With current code, `ldap_create_tree`  is not invoked and the root is not created.  So the imported data are not available.

**Possible drawbacks**

Duplicate definitions of root in the LDAP_ROOT and Custom Ldif files


