### PR TITLE
Allow using both LDAP_ROOT and Custom Ldif data

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -264,6 +264,7 @@ objectClass: organizationalUnit
 ou: users
 
 EOF
+if  is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
     read -r -a users <<< "$(tr ',;' ' ' <<< "${LDAP_USERS}")"
     read -r -a passwords <<< "$(tr ',;' ' ' <<< "${LDAP_PASSWORDS}")"
     local index=0
@@ -293,6 +294,7 @@ objectClass: groupOfNames
 member: ${users[@]/#/cn=},${LDAP_USER_DC/#/ou=},${LDAP_ROOT}
 
 EOF
+fi
     debug_execute ldapadd -f "${LDAP_SHARE_DIR}/tree.ldif" -H "ldapi:///" -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD"
 }
 
@@ -355,10 +357,10 @@ ldap_initialize() {
         else
             # Initialize OpenLDAP with schemas/tree structure
             ldap_add_schemas
+            ldap_create_tree
+
             if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
                 ldap_add_custom_ldifs
-            else
-                ldap_create_tree
             fi
         fi
         ldap_stop


### PR DESCRIPTION
**Description of the change**

Invoke `ldap_create_tree` even if some custom ldif files do exist in `$LDAP_CUSTOM_LDIF_DIR`

**Benefits**

You might have a LDAP_ROOT defined to create the Ldap root **AND** some  Custom Ldif files to create some data under that root (i.e. People).
With current code, `ldap_create_tree`  is not invoked if there are some Custom Ldif files and so the root is not created if it is not defined in those Custom Ldif files.  (And so the imported data are not available .)

LDAP_ADMIN_PASSWORD is also changed by `ldap_create_tree` 

LDAP_USERS, LDAP_PASSWORDS, LDAP_USER_DC and LDAP_GROUP are still ignored as designed in original code.

**Possible drawbacks**

Duplicate definitions of root in the LDAP_ROOT and Custom Ldif files


