### PR TITLE
Adding custom schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_GROUP`: Group used to group created users. Default: **readers**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
 - `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Only files ending in `.ldif` will be used. Default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` will be skipped when `LDAP_CUSTOM_LDIF_DIR` is used. Default: **/ldifs**
+- `LDAP_CUSTOM_SCHEMA_FILE` : Location of a custom internal schema file that could not be added as custom ldif file (i.e. containing some `structuralObjectClass`). Default is **/schema/custom.ldif**"
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.
 


### PR DESCRIPTION
Adding a custom schema with some internal values  (i.e `structuralObjectClass`) in OpenLDAP cannot be achieved using `ldapadd` and ldif files afterwards.
It can only be done using `slapadd` at setup. 

This pull request allows to optionaly add such a schema.  If `LDAP_CUSTOM_SCHEMA_FILE` variable does exist and refers to an existing schema file, then the schema is added using `slapadd` 

