### PR TITLE
Feature/custom schema

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -34,7 +34,7 @@ export LDAP_DATA_DIR="${LDAP_VOLUME_DIR}/data"
 export LDAP_ONLINE_CONF_DIR="${LDAP_VOLUME_DIR}/slapd.d"
 export LDAP_PID_FILE="${LDAP_BASE_DIR}/var/run/slapd.pid"
 export LDAP_CUSTOM_LDIF_DIR="${LDAP_CUSTOM_LDIF_DIR:-/ldifs}"
-export LDAP_CUSTOM_SCHEMA_DIR="${LDAP_CUSTOM_SCHEMA_DIR:-/ldifs}"
+export LDAP_CUSTOM_SCHEMA_DIR="${LDAP_CUSTOM_SCHEMA_DIR:-/schemas}"
 export PATH="${LDAP_BIN_DIR}:${LDAP_SBIN_DIR}:$PATH"
 # Users
 export LDAP_DAEMON_USER="slapd"

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -34,6 +34,7 @@ export LDAP_DATA_DIR="${LDAP_VOLUME_DIR}/data"
 export LDAP_ONLINE_CONF_DIR="${LDAP_VOLUME_DIR}/slapd.d"
 export LDAP_PID_FILE="${LDAP_BASE_DIR}/var/run/slapd.pid"
 export LDAP_CUSTOM_LDIF_DIR="${LDAP_CUSTOM_LDIF_DIR:-/ldifs}"
+export LDAP_CUSTOM_SCHEMA_DIR="${LDAP_CUSTOM_SCHEMA_DIR:-/ldifs}"
 export PATH="${LDAP_BIN_DIR}:${LDAP_SBIN_DIR}:$PATH"
 # Users
 export LDAP_DAEMON_USER="slapd"
@@ -297,6 +298,20 @@ EOF
 }
 
 ########################
+# Add custom schema files
+# Globals:
+#   LDAP_*
+# Arguments:
+#   None
+# Returns
+#   None
+#########################
+ldap_add_custom_schema() {
+    info "Loading custom schema files..."
+    debug_execute for f in $LDAP_CUSTOM_SCHEMA_DIR/*.ldif; do ldapadd -H 'ldapi:///' -f $f; done
+}
+
+########################
 # Add custom LDIF files
 # Globals:
 #   LDAP_*
@@ -355,6 +370,9 @@ ldap_initialize() {
         else
             # Initialize OpenLDAP with schemas/tree structure
             ldap_add_schemas
+            if ! is_dir_empty "$LDAP_CUSTOM_SCHEMA_DIR"; then
+                ldap_add_custom_schema
+            fi
             if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
                 ldap_add_custom_ldifs
             else

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_USER_DC`: DC for the users' organizational unit. Default: **users**
 - `LDAP_GROUP`: Group used to group created users. Default: **readers**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
+- `LDAP_CUSTOM_SCHEMA_DIR`: Location of directory that contain LDIF schema files that should be imported before bootstrapping the database. Only files ending `.ldif` will be used.
 - `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Only files ending in `.ldif` will be used. Default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` will be skipped when `LDAP_CUSTOM_LDIF_DIR` is used. Default: **/ldifs**
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_USER_DC`: DC for the users' organizational unit. Default: **users**
 - `LDAP_GROUP`: Group used to group created users. Default: **readers**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
-- `LDAP_CUSTOM_SCHEMA_DIR`: Location of directory that contain LDIF schema files that should be imported before bootstrapping the database. Only files ending `.ldif` will be used.
+- `LDAP_CUSTOM_SCHEMA_DIR`: Location of directory that contain LDIF schema files that should be imported before bootstrapping the database. Only files ending `.ldif` will be used. Default: **/schemas**
 - `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Only files ending in `.ldif` will be used. Default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` will be skipped when `LDAP_CUSTOM_LDIF_DIR` is used. Default: **/ldifs**
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.


### PR DESCRIPTION
**Description of the change**

Adding new environment variable to load custom schema files from a directory before bootstrapping the database. Similar functionality as to load data from LDIF files in #7 and #8 

**Benefits**

Use is able to load custom schema elements before bootstrapping the database at initial load

**Possible drawbacks**

There was mentioned in #12 that certain schema changes can only be done offline and using "slapadd"

**Applicable issues**

This fixes issue #14 

**Additional information**

There is also pull request #12 which adds similar functionality
