### PR TITLE
avoid shell pipe with debug_execute

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -308,7 +308,10 @@ EOF
 ldap_add_custom_ldifs() {
     info "Loading custom LDIF files..."
     warn "Ignoring LDAP_USERS, LDAP_PASSWORDS, LDAP_USER_DC and LDAP_GROUP environment variables..."
-    debug_execute find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 -type f -iname '*.ldif' -print0 | sort -z | xargs --null -I{} ldapadd -f {} -H 'ldapi:///' -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD"
+    for f in $LDAP_CUSTOM_LDIF_DIR/*.ldif; do
+        info "Processing $f"
+        debug_execute ldapadd -f "$f" -H 'ldapi:///' -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD"
+    done
 }
 
 ########################


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
* LDIF files are not being applied without the use of BITNAMI_DEBUG=true
* Increased log statements to provide feedback to system-admin

**Benefits**
Proper functionality

**Possible drawbacks**
Not assessed

**Applicable issues**
#19 

