### PR TITLE
Change env. var for enabling TLS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/d
 
 OpenLDAP clients and servers are capable of using the Transport Layer Security (TLS) framework to provide integrity and confidentiality protections and to support LDAP authentication using the SASL EXTERNAL mechanism. Should you desire to enable this optional feature, you may use the following enviroment variables to configure the application:
 
- - `LDAP_TLS_ENABLED`: Whether to enable TLS for traffic or not. Defaults to `no`.
+ - `LDAP_ENABLE_TLS`: Whether to enable TLS for traffic or not. Defaults to `no`.
  - `LDAP_LDAPS_PORT_NUMBER`: Port used for TLS secure traffic. Defaults to `1636`.
  - `LDAP_TLS_CERT_FILE`: File containing the certificate file for the TSL traffic. No defaults.
  - `LDAP_TLS_KEY_FILE`: File containing the key for certificate. No defaults.
@@ -199,7 +199,7 @@ This new feature is not mutually exclusive, which means it is possible to listen
         -v /path/to/certs:/opt/bitnami/openldap/certs \
         -v /path/to/openldap-data-persistence:/bitnami/openldap/data \
         -e ALLOW_EMPTY_PASSWORD=yes \
-        -e LDAP_TLS_ENABLED=yes \
+        -e LDAP_ENABLE_TLS=yes \
         -e LDAP_TLS_CERT_FILE=/opt/bitnami/openldap/certs/openldap.crt \
         -e LDAP_TLS_KEY_FILE=/opt/bitnami/openldap/certs/openldap.key \
         -e LDAP_TLS_CA_FILE=/opt/bitnami/openldap/certs/openldapCA.crt \
@@ -214,7 +214,7 @@ This new feature is not mutually exclusive, which means it is possible to listen
       ...
         environment:
           ...
-          - LDAP_TLS_ENABLED=yes
+          - LDAP_ENABLE_TLS=yes
           - LDAP_TLS_CERT_FILE=/opt/bitnami/openldap/certs/openldap.crt
           - LDAP_TLS_KEY_FILE=/opt/bitnami/openldap/certs/openldap.key
           - LDAP_TLS_CA_FILE=/opt/bitnami/openldap/certs/openldapCA.crt


### PR DESCRIPTION
**Description of the change**

Previously to this PR, there was an inconsistency between the env. variable documented in the README and the one used in the scripts, see:
```console
$ ag 'LDAP_TLS_ENABLED'
README.md
187: - `LDAP_TLS_ENABLED`: Whether to enable TLS for traffic or not. Defaults to `no`.
202:        -e LDAP_TLS_ENABLED=yes \
217:          - LDAP_TLS_ENABLED=yes

$ ag 'LDAP_ENABLE_TLS'
2/debian-10/rootfs/opt/bitnami/scripts/openldap/run.sh
19:is_boolean_yes "$LDAP_ENABLE_TLS" && flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldaps://:${LDAP_LDAPS_PORT_NUMBER}/ ldapi:///")

2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
57:export LDAP_ENABLE_TLS="${LDAP_ENABLE_TLS:-no}"
87:    for var in LDAP_SKIP_DEFAULT_TREE LDAP_ENABLE_TLS; do
93:    if is_boolean_yes "$LDAP_ENABLE_TLS"; then
376:        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
```
being `LDAP_TLS_ENABLED` the one appearing in the docs and `LDAP_ENABLE_TLS` the one used in the scripts.

Those changes fix this issue, being `LDAP_ENABLE_TLS` used everywhere:
```console
$ ag 'LDAP_TLS_ENABLED'

$ ag 'LDAP_ENABLE_TLS'
2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
57:export LDAP_ENABLE_TLS="${LDAP_ENABLE_TLS:-no}"
87:    for var in LDAP_SKIP_DEFAULT_TREE LDAP_ENABLE_TLS; do
93:    if is_boolean_yes "$LDAP_ENABLE_TLS"; then
376:        if is_boolean_yes "$LDAP_ENABLE_TLS"; then

2/debian-10/rootfs/opt/bitnami/scripts/openldap/run.sh
19:is_boolean_yes "$LDAP_ENABLE_TLS" && flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldaps://:${LDAP_LDAPS_PORT_NUMBER}/ ldapi:///")

README.md
187: - `LDAP_ENABLE_TLS`: Whether to enable TLS for traffic or not. Defaults to `no`.
202:        -e LDAP_ENABLE_TLS=yes \
217:          - LDAP_ENABLE_TLS=yes
```

**Applicable issues**

- Fixes #23

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
