### PR TITLE
Allow for schema addition without default tree during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Launch the containers using:
 $ docker-compose up -d
 ```
 
+# Database bootstrap
+
+On the first run (i.e. if the binded volume is empty), the database is initialized. The `core`, `cosine`, `inetperson`, and `nis` schemas are added, and a default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` is created.
+
+You may skip the default tree creation (when `LDAP_SKIP_DEFAULT_TREE` is **yes**), which means there won't be any directory entry, not even the root entry (`organization` object class).
+
+You may also provide custom LDIF files (at `LDAP_CUSTOM_LDIF_DIR`). When at least one file is provided, only the `core` schema will be added, and of course the default tree will be skipped. Only files ending in `.ldif` will be used. As they are sorted by name, you are able to control their order of execution, if needed.
+
 # Configuration
 
 The Bitnami Docker OpenLDAP can be easily setup with the following environment variables:
@@ -176,7 +184,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_USER_DC`: DC for the users' organizational unit. Default: **users**
 - `LDAP_GROUP`: Group used to group created users. Default: **readers**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
-- `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Only files ending in `.ldif` will be used. Default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` will be skipped when `LDAP_CUSTOM_LDIF_DIR` is used. When using this will override the usage of `LDAP_ROOT`,`LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **/ldifs**
+- `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Default: **/ldifs**
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

It is currently not possible to skip default tree generation while having default schemas. While these default schemas could be added in the custom LDIF directory, they are also part of OpenLDAP, i.e. they are already embedded in the Docker image. If someday the defaults change (see #26), or less likely the files change, I'd like that they also change for me, which won't happen if I had to copy them in a own directory.

Well, the patch just inverts two nested tests.

**Benefits**

Having default schemas with a custom organization tree.

**Possible drawbacks**

Configuration with `LDAP_SKIP_DEFAULT_TREE=yes` and an empty `LDAP_CUSTOM_LDIF_DIR` had only the core schema before this patch, and will have extra schemas (cosine, inetorgperson, nis) thereafter. IMHO `LDAP_SKIP_DEFAULT_TREE=yes` should be used when `LDAP_CUSTOM_LDIF_DIR` is not empty, so the case should be rare.

**Applicable issues**

None

**Additional information**

Not important: I think this comment adds little value. https://github.com/bitnami/bitnami-docker-openldap/blob/master/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh#L382
