### PR TITLE
add configuration option for TLS DH parameter file

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -39,6 +39,7 @@ export PATH="${LDAP_BIN_DIR}:${LDAP_SBIN_DIR}:$PATH"
 export LDAP_TLS_CERT_FILE="${LDAP_TLS_CERT_FILE:-}"
 export LDAP_TLS_KEY_FILE="${LDAP_TLS_KEY_FILE:-}"
 export LDAP_TLS_CA_FILE="${LDAP_TLS_CA_FILE:-}"
+export LDAP_TLS_DH_PARAMS_FILE="${LDAP_TLS_DH_PARAMS_FILE:-}"
 # Users
 export LDAP_DAEMON_USER="slapd"
 export LDAP_DAEMON_GROUP="slapd"
@@ -444,6 +445,9 @@ olcTLSCertificateFile: $LDAP_TLS_CERT_FILE
 -
 replace: olcTLSCertificateKeyFile
 olcTLSCertificateKeyFile: $LDAP_TLS_KEY_FILE
+-
+replace: olcTLSDHParamFile
+olcTLSDHParamFile: $LDAP_TLS_DH_PARAMS_FILE
 
 EOF
     debug_execute ldapmodify -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/certs.ldif"

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -445,10 +445,16 @@ olcTLSCertificateFile: $LDAP_TLS_CERT_FILE
 -
 replace: olcTLSCertificateKeyFile
 olcTLSCertificateKeyFile: $LDAP_TLS_KEY_FILE
+EOF
+
+    if [[ ! -z "$LDAP_TLS_DH_PARAMS_FILE" ]] ; then
+      cat >> "${LDAP_SHARE_DIR}/certs.ldif" << EOF
 -
 replace: olcTLSDHParamFile
 olcTLSDHParamFile: $LDAP_TLS_DH_PARAMS_FILE
-
 EOF
+
+    fi
+
     debug_execute ldapmodify -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/certs.ldif"
 }

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ OpenLDAP clients and servers are capable of using the Transport Layer Security (
  - `LDAP_TLS_CERT_FILE`: File containing the certificate file for the TSL traffic. No defaults.
  - `LDAP_TLS_KEY_FILE`: File containing the key for certificate. No defaults.
  - `LDAP_TLS_CA_FILE`: File containing the CA of the certificate. No defaults.
+ - `LDAP_TLS_DH_PARAMS_FILE`: File containing the DH paramters. No defaults.
 
 This new feature is not mutually exclusive, which means it is possible to listen to both TLS and non-TLS connection simultaneously. To use TLS you can use the URI `ldaps://openldap:1636` or use the non-TLS URI forcing ldap to use TLS `ldap://openldap:1389 -ZZ`.
 


### PR DESCRIPTION
Added configuration paramter to define DH parameter file.

modifies configuration for olcTLSDHParamFile (dn = cn=config)