### PR TITLE
Allow arbitrary server configuration before/after custom LDIF files load

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -34,6 +34,8 @@ export LDAP_DATA_DIR="${LDAP_VOLUME_DIR}/data"
 export LDAP_ONLINE_CONF_DIR="${LDAP_VOLUME_DIR}/slapd.d"
 export LDAP_PID_FILE="${LDAP_BASE_DIR}/var/run/slapd.pid"
 export LDAP_CUSTOM_LDIF_DIR="${LDAP_CUSTOM_LDIF_DIR:-/ldifs}"
+export LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR="${LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR:-/server_config_before_custom_ldifs}"
+export LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR="${LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR:-/server_config_after_custom_ldifs}"
 export LDAP_CUSTOM_SCHEMA_FILE="${LDAP_CUSTOM_SCHEMA_FILE:-/schema/custom.ldif}"
 export PATH="${LDAP_BIN_DIR}:${LDAP_SBIN_DIR}:$PATH"
 export LDAP_TLS_CERT_FILE="${LDAP_TLS_CERT_FILE:-}"
@@ -349,7 +351,7 @@ EOF
 }
 
 ########################
-# Add custom LDIF files
+# Add custom LDIF files as the admin user
 # Globals:
 #   LDAP_*
 # Arguments:
@@ -361,6 +363,21 @@ ldap_add_custom_ldifs() {
     info "Loading custom LDIF files..."
     warn "Ignoring LDAP_USERS, LDAP_PASSWORDS, LDAP_USER_DC and LDAP_GROUP environment variables..."
     find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print0 | sort -z | xargs --null -I{} bash -c ". /opt/bitnami/scripts/libos.sh && debug_execute ldapadd -f {} -H 'ldapi:///' -D $LDAP_ADMIN_DN -w $LDAP_ADMIN_PASSWORD"
+}
+
+########################
+# Add custom server config LDIF files using the same SASL/EXTERNAL authentication which is used for other server configuration
+# Globals:
+#   LDAP_*
+# Arguments:
+#   $1 - name of the variable whose value is the directory containing LDIF files which should be loaded
+# Returns
+#   None
+#########################
+ldap_add_custom_server_config_ldifs() {
+    info "Loading custom server config LDIF files..."
+    directory_variable_name=$1
+    find "${!directory_variable_name}" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print0 | sort -z | xargs --null -I{} bash -c ". /opt/bitnami/scripts/libos.sh && debug_execute ldapadd -f {} -Y EXTERNAL -H 'ldapi:///'"
 }
 
 ########################
@@ -413,10 +430,16 @@ ldap_initialize() {
             if [[ -f "$LDAP_CUSTOM_SCHEMA_FILE" ]]; then
                 ldap_add_custom_schema
             fi
+            if ! is_dir_empty "$LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR"; then
+                ldap_add_custom_server_config_ldifs LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR
+            fi
             if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
                 ldap_add_custom_ldifs
             else
                 ldap_create_tree
+            fi
+            if ! is_dir_empty "$LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR"; then
+                ldap_add_custom_server_config_ldifs LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR
             fi
         fi
         ldap_stop

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_EXTRA_SCHEMAS`: Extra schemas to add, among OpenLDAP's distributed schemas. Default: **cosine, inetorgperson, nis**
 - `LDAP_SKIP_DEFAULT_TREE`: Whether to skip creating the default LDAP tree based on `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **no**
 - `LDAP_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to bootstrap the database. Only files ending in `.ldif` will be used. Default LDAP tree based on the `LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP` will be skipped when `LDAP_CUSTOM_LDIF_DIR` is used. When using this will override the usage of `LDAP_ROOT`,`LDAP_USERS`, `LDAP_PASSWORDS`, `LDAP_USER_DC` and `LDAP_GROUP`. Default: **/ldifs**
+- `LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to further configure the server. Only files ending in `.ldif` will be used. Loaded *before* the `$LDAP_CUSTOM_LDIF_DIR` files. Default: **/server_config_before_custom_ldifs**
+- `LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR`: Location of a directory that contains LDIF files that should be used to further configure the server. Only files ending in `.ldif` will be used. Loaded *after* the `$LDAP_CUSTOM_LDIF_DIR` files. Default: **/server_config_after_custom_ldifs**
 - `LDAP_CUSTOM_SCHEMA_FILE`: Location of a custom internal schema file that could not be added as custom ldif file (i.e. containing some `structuralObjectClass`). Default is **/schema/custom.ldif**"
 - `LDAP_ULIMIT_NOFILES`: Maximum number of open file descriptors. Default: **1024**.
 


### PR DESCRIPTION
**Description of the change**

We use this excellent container image in our integration tests for our open source project https://github.com/vmware-tanzu/pinniped

We wanted to be able to further configure our openldap server to use the `memberOf` overlay and to require that clients connect using TLS/StartTLS. I couldn't figure out a way to accomplish either of these objectives with bitnami/bitnami-docker-openldap, hence this PR to make both possible. You already offer `$LDAP_CUSTOM_LDIF_DIR` to execute arbitrary LDIF, but those files are loaded by the admin user, and that user does not seem to have permission to reconfigure the server.

New features added in the PR:
- Optionally load LDIF files to configure the server before the custom LDIF files are loaded as the admin user. This allows configuring things which need to exist before users and groups are created, such as the `memberOf` overlay. This is controlled by the new `$LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR` env var.
- Also optionally load other LDIF files to configure the server after the custom LDIF files are loaded as the admin user. This allows configuring things which need to happen after the users and groups are created, such as disabling all non-TLS client connections, which needs to happen after the users/groups are created or else the connection used to create them will be rejected for not using TLS. This is controlled by the new `$LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR` env var.

You can see how we are planning to use these features in this example deployment, which is how we deploy openldap for our integration tests: https://github.com/vmware-tanzu/pinniped/blob/ldap_starttls/test/deploy/tools/ldap.yaml

I am not an openldap expert, so its entirely possible that there may be a better way to accomplish these outcomes. I would love to hear your feedback.

**Benefits**

Ability to further configure the openldap server.

**Possible drawbacks**

Maybe too many configuration options. :)

**Applicable issues**

These seem related: #22 #30 #17 

**Additional information**

Thanks for considering this PR!
