### PR TITLE
Wait for LDAP database files to unlock after stopping. 

### DIFF
--- a/2/debian-10/Dockerfile
+++ b/2/debian-10/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/" \
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages acl ca-certificates curl gzip libc6 libdb5.3 libltdl7 libnss3-tools libodbc1 libperl5.28 libsasl2-2 libssl1.1 libwrap0 mdbtools procps tar
+RUN install_packages acl ca-certificates curl gzip libc6 libdb5.3 libltdl7 libnss3-tools libodbc1 libperl5.28 libsasl2-2 libssl1.1 libwrap0 mdbtools procps tar lsof
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "openldap" "2.4.58-0" --checksum 824d0af37f006a07f4f887a973df5cce64e2dd037256d2aef31121ddfabce883
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-2" --checksum 4d858ac600c38af8de454c27b7f65c0074ec3069880cb16d259a6e40a46bbc50
 RUN chmod g+rwX /opt/bitnami


### PR DESCRIPTION
**Description of the change**

This change updates the `ldap_stop` function to make sure that all the files under `$LDAP_DATA_DIR` are closed after signaling the OpenLDAP process to exit.
This fixes a race condition where subsequent steps could fail with a "database already in use" error.

**Benefits**

This should make the startup more reliable, eliminating the race condition documented in #1. I was able to consistently reproduce the bug locally prior to this patch. With this change, I've not seen a failure.

**Possible drawbacks**

None of which I'm aware.

**Applicable issues**

#1

**Additional information**

I also tried a simple one-line patch to add a `sleep 1`, which worked but seemed clunkier. There was a previous version of this PR which only waited for the LDAP process to exit (https://github.com/bitnami/bitnami-docker-openldap/pull/35/commits/124f774cf3854573d9441c3311a511c9af47f440). The final approach was chosen as the most reliable.