### PR TITLE
Update README.md with the right env vars on mariadb-galera docker command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ docker run --detach --rm --name mariadb-galera \
     --env MARIADB_DATABASE=customdatabase \
     --env MARIADB_ENABLE_LDAP=yes \
     --env LDAP_URI=ldap://openldap:1389 \
-    --env LDAP_ROOT=dc=example,dc=org \
+    --env LDAP_BASE=dc=example,dc=org \
     --env LDAP_BIND_DN=cn=admin,dc=example,dc=org \
     --env LDAP_BIND_PASSWORD=adminpassword \
     bitnami/mariadb-galera:latest


### PR DESCRIPTION
**Description of the change**

When using the docker container command line instructions, the mariadb command is using the wrong LDAP_ROOT env variable. The mariadb-galera image uses LDAP_BASE instead.
Not sure which one is wrong so I'll leave it here since it's related to documentation only.

**Benefits**

Without this change the mariadb-galera container will fail with and error
```
ERROR ==> The LDAP configuration is required when LDAP authentication is enabled. Set the environment variables LDAP_URI, LDAP_BASE, LDAP_BIND_DN and LDAP_BIND_PASSWORD with the LDAP configuration.
```
Could be frustrating to beginners if these simple examples don't work properly.

**Possible drawbacks**

None

**Applicable issues**

NA

**Additional information**
Maybe there should be some consistency on the env vars used by different container images within Bitnami image set. Looking for perfection here.
