### PR TITLE
added custom initscript feature

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/openldap/setup.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/openldap/setup.sh
@@ -19,3 +19,5 @@ ldap_validate
 am_i_root && ensure_user_exists "$LDAP_DAEMON_USER" --group "$LDAP_DAEMON_GROUP"
 # Ensure Open LDAP server is initialize
 ldap_initialize
+# Allow running custom initialization scripts
+ldap_custom_init_scripts

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 - `LDAP_CUSTOM_SCHEMA_FILE`: Location of a custom internal schema file that could not be added as custom ldif file (i.e. containing some `structuralObjectClass`). Default is **/schema/custom.ldif**"
 - `LDAP_ULIMIT_NOFILES`: Maximum number of open file descriptors. Default: **1024**.
 
+## Customize a new OpenLDAP container
+The [Bitnami OpenLDAP](https://github.com/bitnami/bitnami-docker-openldap) image allows you to use your custom scripts to initialize a fresh instance.
+
+The allowed script extension is `.sh`, all scripts are executed in alphabetical order and need to reside in `/docker-entrypoint-initdb.d/`.
+
+Scripts are executed are after the initilization and before the startup of the OpenLDAP service.
+
+
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.
 
 ## Securing OpenLDAP traffic


### PR DESCRIPTION
**Description of the change**
adding posibility of custom init scripts

**Benefits**
more flexible way of initializing complex import/restore scenarios

**Possible drawbacks**
none known

**Applicable issues**
n/a

**Additional information**
caused by PR #44

this is basically a copy of the `mysql_custom_init_scripts`-function from [bitnami-docker-mysql](https://github.com/bitnami/bitnami-docker-mysql)