### PR TITLE
Fix regression in config admin init

### DIFF
--- a/2.4/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2.4/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -262,10 +262,12 @@ olcAccess: {0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external, 
 EOF
     if is_boolean_yes "$LDAP_CONFIG_ADMIN_ENABLED"; then
         cat >> "${LDAP_SHARE_DIR}/admin.ldif" << EOF
+
 dn: olcDatabase={0}config,cn=config
 changetype: modify
 add: olcRootDN
 olcRootDN: $LDAP_CONFIG_ADMIN_DN
+
 dn: olcDatabase={0}config,cn=config
 changetype: modify
 add: olcRootPW

--- a/2.5/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2.5/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -262,10 +262,12 @@ olcAccess: {0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external, 
 EOF
     if is_boolean_yes "$LDAP_CONFIG_ADMIN_ENABLED"; then
         cat >> "${LDAP_SHARE_DIR}/admin.ldif" << EOF
+
 dn: olcDatabase={0}config,cn=config
 changetype: modify
 add: olcRootDN
 olcRootDN: $LDAP_CONFIG_ADMIN_DN
+
 dn: olcDatabase={0}config,cn=config
 changetype: modify
 add: olcRootPW


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix regression from commits 3d0c897636816d2ecb6e2373a1c52f4fa38d42ff and 737506a088b57aa0ef38ca407d7f0efc34eb7e92

Missing newlines caused incorrect ldif to be generated during db initialization when config admin is enabled. Related to #42 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
