### PR TITLE
Fix missing quotes in ldapadd #55

### DIFF
--- a/2.4/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2.4/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -415,7 +415,7 @@ EOF
 ldap_add_custom_ldifs() {
     info "Loading custom LDIF files..."
     warn "Ignoring LDAP_USERS, LDAP_PASSWORDS, LDAP_USER_DC and LDAP_GROUP environment variables..."
-    find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print0 | sort -z | xargs --null -I{} bash -c ". /opt/bitnami/scripts/libos.sh && debug_execute ldapadd -f {} -H 'ldapi:///' -D $LDAP_ADMIN_DN -w $LDAP_ADMIN_PASSWORD"
+    find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print0 | sort -z | xargs --null -I{} bash -c ". /opt/bitnami/scripts/libos.sh && debug_execute ldapadd -f {} -H 'ldapi:///' -D \"$LDAP_ADMIN_DN\" -w \"$LDAP_ADMIN_PASSWORD\""
 }
 
 ########################

--- a/2.5/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2.5/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -415,7 +415,7 @@ EOF
 ldap_add_custom_ldifs() {
     info "Loading custom LDIF files..."
     warn "Ignoring LDAP_USERS, LDAP_PASSWORDS, LDAP_USER_DC and LDAP_GROUP environment variables..."
-    find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print0 | sort -z | xargs --null -I{} bash -c ". /opt/bitnami/scripts/libos.sh && debug_execute ldapadd -f {} -H 'ldapi:///' -D $LDAP_ADMIN_DN -w $LDAP_ADMIN_PASSWORD"
+    find "$LDAP_CUSTOM_LDIF_DIR" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print0 | sort -z | xargs --null -I{} bash -c ". /opt/bitnami/scripts/libos.sh && debug_execute ldapadd -f {} -H 'ldapi:///' -D \"$LDAP_ADMIN_DN\" -w \"$LDAP_ADMIN_PASSWORD\""
 }
 
 ########################


### PR DESCRIPTION
**Description of the change**

This change adds quotes to the variables `LDAP_ADMIN_DN` and `LDAP_ADMIN_PASSWORD` of the shell command ldapadd if there are ldif files provided in the `LDAP_CUSTOM_LDIF_DIR`.

**Benefits**

If there are spaces or wildcards in on of those variables the ldapadd command will fail. This pull request fixes that.

**Possible drawbacks**

None

**Applicable issues**

- fixes #55 

