### PR TITLE
README.md: use admin guide for 2.5 instead of 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 
 You can bootstrap the contents of your database by putting LDIF files in the directory `/ldifs` (or the one you define in `LDAP_CUSTOM_LDIF_DIR`). Those may only contain content underneath your base DN (set by `LDAP_ROOT`). You can **not** set configuration for e.g. `cn=config` in those files.
 
-Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin24/guide.html) for more information about how to configure OpenLDAP.
+Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin25/guide.html) for more information about how to configure OpenLDAP.
 
 ### Securing OpenLDAP traffic
 


### PR DESCRIPTION
Signed-off-by: Johannes Kastl <kastl@b1-systems.de>

**Description of the change**

use link to admin guide for version 2.5 in the Readme, as this image uses 2.5.

**Benefits**

Documentation matching the application version

**Possible drawbacks**

None