### PR TITLE
README.md: change persistence example to also capture /bitnami/openldap/slapd.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This new feature is not mutually exclusive, which means it is possible to listen
     ```console
     $ docker run --name openldap \
         -v /path/to/certs:/opt/bitnami/openldap/certs \
-        -v /path/to/openldap-data-persistence:/bitnami/openldap/data \
+        -v /path/to/openldap-data-persistence:/bitnami/openldap/ \
         -e ALLOW_EMPTY_PASSWORD=yes \
         -e LDAP_ENABLE_TLS=yes \
         -e LDAP_TLS_CERT_FILE=/opt/bitnami/openldap/certs/openldap.crt \
@@ -240,7 +240,7 @@ This new feature is not mutually exclusive, which means it is possible to listen
         ...
         volumes:
           - /path/to/certs:/opt/bitnami/openldap/certs
-          - /path/to/openldap-data-persistence:/bitnami/openldap/data
+          - /path/to/openldap-data-persistence:/bitnami/openldap/
       ...
     ```
 


### PR DESCRIPTION
Examples: mount volume to /bitnami/openldap/ (not to /bitnami/openldap/data) to also capture /bitnami/openldap/slapd.d/

Signed-off-by: Johannes Kastl <kastl@b1-systems.de>

**Description of the change**

The image is configured to store the actual slapd database in `/bitnami/openldap/data`, but it keeps the configuration (`cn=config` etc.) in `/bitnami/openldap/slapd.d/`.

The examples currently only persist `/bitnami/openldap/data`.

**Applicable issues**

noticed this in Kubernetes in #89