### PR TITLE
Allow use of privileged ports

### DIFF
--- a/2.5/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2.5/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -46,6 +46,7 @@ export LDAP_DAEMON_GROUP="slapd"
 # Settings
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
+export LDAP_ALLOW_PRIVILEGED_PORTS="${LDAP_ALLOW_PRIVILEGED_PORTS:-no}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
 export LDAP_ADMIN_USERNAME="${LDAP_ADMIN_USERNAME:-admin}"
 export LDAP_ADMIN_DN="${LDAP_ADMIN_USERNAME/#/cn=},${LDAP_ROOT}"
@@ -91,7 +92,9 @@ ldap_validate() {
     check_allowed_port() {
         local port_var="${1:?missing port variable}"
         local validate_port_args=()
-        ! am_i_root && validate_port_args+=("-unprivileged")
+        if ! am_i_root && ! is_boolean_yes "$LDAP_ALLOW_PRIVILEGED_PORTS"; then
+            validate_port_args+=("-unprivileged")
+        fi
         if ! err=$(validate_port "${validate_port_args[@]}" "${!port_var}"); then
             print_validation_error "An invalid port was specified in the environment variable ${port_var}: ${err}."
         fi

--- a/2.6/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/2.6/debian-10/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -46,6 +46,7 @@ export LDAP_DAEMON_GROUP="slapd"
 # Settings
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
+export LDAP_ALLOW_PRIVILEGED_PORTS="${LDAP_ALLOW_PRIVILEGED_PORTS:-no}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
 export LDAP_ADMIN_USERNAME="${LDAP_ADMIN_USERNAME:-admin}"
 export LDAP_ADMIN_DN="${LDAP_ADMIN_USERNAME/#/cn=},${LDAP_ROOT}"
@@ -91,7 +92,9 @@ ldap_validate() {
     check_allowed_port() {
         local port_var="${1:?missing port variable}"
         local validate_port_args=()
-        ! am_i_root && validate_port_args+=("-unprivileged")
+        if ! am_i_root && ! is_boolean_yes "$LDAP_ALLOW_PRIVILEGED_PORTS"; then
+            validate_port_args+=("-unprivileged")
+        fi
         if ! err=$(validate_port "${validate_port_args[@]}" "${!port_var}"); then
             print_validation_error "An invalid port was specified in the environment variable ${port_var}: ${err}."
         fi

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ $ docker-compose up -d
 The Bitnami Docker OpenLDAP can be easily setup with the following environment variables:
 
 - `LDAP_PORT_NUMBER`: The port OpenLDAP is listening for requests. Default: **1389** (non privileged port)
+- `LDAP_ALLOW_PRIVILEGED_PORTS`: Allow OpenLDAP to bind to privileged (<1024) ports. Setting this variable to `yes` only disables checks. Default: **no** (only non privileged ports are allowed)
 - `LDAP_ROOT`: LDAP baseDN (or suffix) of the LDAP tree. Default: **dc=example,dc=org**
 - `LDAP_ADMIN_USERNAME`: LDAP database admin user. Default: **admin**
 - `LDAP_ADMIN_PASSWORD`: LDAP database admin password. Default: **adminpassword**
@@ -251,6 +252,36 @@ The [Bitnami OpenLDAP](https://github.com/bitnami/bitnami-docker-openldap) image
 The allowed script extension is `.sh`, all scripts are executed in alphabetical order and need to reside in `/docker-entrypoint-initdb.d/`.
 
 Scripts are executed are after the initilization and before the startup of the OpenLDAP service.
+
+### Bind to privileged ports in the container
+
+Setting the environment variable `LDAP_ALLOW_PRIVILEGED_PORTS=true` will disable checks that normally prevent OpenLDAP in the container from binding to privileged ports, like the standard LDAP port 389 and LDAPS port 636.
+
+This is not enough to allow OpenLDAP to bind to privileged ports, and you should additionally grant your container the capability `NET_BIND_SERVICE` for it to work.
+
+1. Using `docker run`:
+
+  ```console
+  $ docker run --cap-add=NET_BIND_SERVICE --env LDAP_PORT_NUMBER=389 --env LDAP_ALLOW_PRIVILEGED_PORTS=yes docker.io/bitnami/openldap:latest
+  ```
+
+2. Modifying the `docker-compose.yml` file present in this repository:
+
+    ```yaml
+    services:
+      openldap:
+      ...
+        cap_add:
+          - NET_BIND_SERVICE
+        environment:
+          ...
+          - LDAP_PORT_NUMBER=389
+          - LDAP_ALLOW_PRIVILEGED_PORTS=yes
+        ...
+      ...
+    ```
+
+Example docker-compose.yml file:
 
 ## Logging
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Make it possible to disable checks for whether privileged ports are being used for LDAP/LDAPS (i.e. to use the standard LDAP/LDAPS ports within the container).

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Without the container being granted the capability to bind privileged ports, it will fail out with a non-zero return code. Added documentation to explain this.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

This PR resolves bitnami/containers#989.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
